### PR TITLE
Codify gpp detection workaround for OSX 15.1

### DIFF
--- a/lib/nmatrix/mkmf.rb
+++ b/lib/nmatrix/mkmf.rb
@@ -49,14 +49,20 @@ def find_newer_gplusplus #:nodoc:
 end
 
 def gplusplus_version
-  cxxvar = proc { |n| `#{CONFIG['CXX']} -E -dM - <#{File::NULL} | grep #{n}`.chomp.split(' ')[2] }
-  major = cxxvar.call('__GNUC__')
-  minor = cxxvar.call('__GNUC_MINOR__')
-  patch = cxxvar.call('__GNUC_PATCHLEVEL__')
+  ver = nil
+  [CONFIG['CXX'], "g++ -fdeclspec"].each do |gpp_command|
+    cxxvar = proc { |n| `#{gpp_command} -E -dM - <#{File::NULL} | grep #{n}`.chomp.split(' ')[2] }
+    major = cxxvar.call('__GNUC__')
+    minor = cxxvar.call('__GNUC_MINOR__')
+    patch = cxxvar.call('__GNUC_PATCHLEVEL__')
 
-  raise("unable to determine g++ version (match to get version was nil)") if major.nil? || minor.nil? || patch.nil?
-  ver = "#{major}.#{minor}.#{patch}"
-  puts "g++ version discovered: " + ver
+    next if major.nil? || minor.nil? || patch.nil?
+
+    ver = "#{major}.#{minor}.#{patch}"
+    puts "g++ version discovered: " + ver
+  end
+  
+  raise("unable to determine g++ version (match to get version was nil)") if ver.nil?
   ver
 end
 

--- a/lib/nmatrix/version.rb
+++ b/lib/nmatrix/version.rb
@@ -29,7 +29,7 @@ class NMatrix
   module VERSION #:nodoc:
     MAJOR = 0
     MINOR = 2
-    TINY = 4
+    TINY = 5
     #PRE = "a"
 
     STRING = [MAJOR, MINOR, TINY].compact.join(".")


### PR DESCRIPTION
The [Alignable hack](https://github.com/Alignable/AlignableWeb/blob/c47266e008a353db22a34a5aaeb1505e8d8418cc/rails/README.md?plain=1#L130) to get this gem working stopped working on my install for whatever reason.

It probably has to do with being on Sequoia and that my version of ruby had to be [manually patched](https://github.com/rvm/rvm/issues/5507#issuecomment-2411632552) to get it working on more modern OSes. Pushing the workaround remotely works for whatever reason.

Can test locally by pointing to the fork

```
gem "nmatrix",
    git: "https://github.com/choladay/nmatrix.git",
    ref: "eca6a28e42105d780c41bf27030c073c4e053e62"
```