### PR TITLE
[DO NOT MERGE] Choladay/0 2 6 assume modern cpp

### DIFF
--- a/lib/nmatrix/mkmf.rb
+++ b/lib/nmatrix/mkmf.rb
@@ -81,15 +81,7 @@ end
 if CONFIG['CXX'] == 'clang++'
   $CXX_STANDARD = 'c++11'
 else
-  version = gplusplus_version
-  if version < '4.3.0' && CONFIG['CXX'] == 'g++'  # see if we can find a newer G++, unless it's been overridden by user
-    if !find_newer_gplusplus
-      raise("You need a version of g++ which supports -std=c++0x or -std=c++11. If you're on a Mac and using Homebrew, we recommend using mac-brew-gcc.sh to install a more recent g++.")
-    end
-    version = gplusplus_version
-  end
-
-  if version < '4.7.0'
+  if gplusplus_version < '4.7.0'
     $CXX_STANDARD = 'c++0x'
   else
     $CXX_STANDARD = 'c++11'

--- a/lib/nmatrix/version.rb
+++ b/lib/nmatrix/version.rb
@@ -29,7 +29,7 @@ class NMatrix
   module VERSION #:nodoc:
     MAJOR = 0
     MINOR = 2
-    TINY = 5
+    TINY = 6
     #PRE = "a"
 
     STRING = [MAJOR, MINOR, TINY].compact.join(".")


### PR DESCRIPTION
Get nmatrix working on OSX 15.4

This[ check was introduced 13 years ago ](https://github.com/Alignable/nmatrix/blob/70930b595107ae1ea81bf9f1fa36b869b11ae2a9/ext/nmatrix/extconf.rb) to make sure your machine has a modern c compiler, I think it's safe to assume anyone running this will have a modern enough compiler for this gem.

This PR exists only to unblock people getting their dev env up.  We should remove nmatrix instead.